### PR TITLE
[AD-1] Add valueToExpr

### DIFF
--- a/auxx/cardano-sl-auxx.cabal
+++ b/auxx/cardano-sl-auxx.cabal
@@ -206,15 +206,16 @@ test-suite cardano-auxx-test
                      , ansi-wl-pprint
                      , base
                      , bytestring
-                     , constraints
                      , cardano-sl-auxx
                      , cardano-sl-core
                      , cardano-sl-crypto
                      , cardano-sl-util
+                     , constraints
                      , formatting
                      , generic-arbitrary
-                     , mtl
                      , hspec
+                     , mtl
+                     , text
                      , universum >= 0.1.11
 
   hs-source-dirs:      test

--- a/auxx/src/Command/Proc.hs
+++ b/auxx/src/Command/Proc.hs
@@ -27,7 +27,7 @@ import           Pos.Crypto (PublicKey, emptyPassphrase, encToPublic, fullPublic
                              noPassEncrypt, safeCreatePsk, unsafeCheatingHashCoerce, withSafeSigner)
 import           Pos.DB.Class (MonadGState (..))
 import           Pos.Diffusion.Types (Diffusion (..))
-import           Pos.Update (BlockVersionModifier (..), BlockVersionData)
+import           Pos.Update (BlockVersionData, BlockVersionModifier (..))
 import           Pos.Util.CompileInfo (HasCompileInfo)
 import           Pos.Util.UserSecret (WalletUserSecret (..), readUserSecret, usKeys, usPrimKey,
                                       usWallet, userSecret)
@@ -42,7 +42,7 @@ import           Command.TyProjection (tyAddrDistrPart, tyAddrStakeDistr, tyAddr
                                        tyBool, tyByte, tyCoin, tyCoinPortion, tyEither,
                                        tyEpochIndex, tyFilePath, tyHash, tyInt,
                                        tyProposeUpdateSystem, tyPublicKey, tyScriptVersion,
-                                       tySecond, tyString, tySoftwareVersion, tyStakeholderId,
+                                       tySecond, tySoftwareVersion, tyStakeholderId, tyString,
                                        tySystemTag, tyTxOut, tyValue, tyWord, tyWord32)
 import qualified Command.Update as Update
 import           Lang.Argument (getArg, getArgMany, getArgOpt, getArgSome, typeDirectedKwAnn)
@@ -357,7 +357,7 @@ createCommandProcs hasMonadIO hasAuxxMode printAction mDiffusion = rights . fix 
     , cpHelp = "propose an update with one positive vote for it \
                \ using secret key #i"
     },
-    
+
     let name = "hash-installer" in
     needMonadIO name >>= \Dict ->
     return CommandProc
@@ -515,8 +515,8 @@ createCommandProcs hasMonadIO hasAuxxMode printAction mDiffusion = rights . fix 
     }]
   where
     needMonadIO :: Name -> Either UnavailableCommand (Dict (MonadIO m, CanLog m, HasLoggerName m))
-    needMonadIO name = 
-        maybe (Left $ UnavailableCommand name "MonadIO is not available") Right hasMonadIO 
+    needMonadIO name =
+        maybe (Left $ UnavailableCommand name "MonadIO is not available") Right hasMonadIO
     needsAuxxMode :: Name -> Either UnavailableCommand (Dict (MonadAuxxMode m))
     needsAuxxMode name =
         maybe (Left $ UnavailableCommand name "AuxxMode is not available") Right hasAuxxMode

--- a/auxx/src/Lang/Name.hs
+++ b/auxx/src/Lang/Name.hs
@@ -13,7 +13,7 @@ import           Data.Coerce (coerce)
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.List.Split (splitWhen)
 import qualified Data.Text.Buildable as Buildable
-import           Test.QuickCheck.Arbitrary.Generic (Arbitrary (..), genericArbitrary, genericShrink)
+import           Test.QuickCheck (Arbitrary (..), genericShrink)
 import           Test.QuickCheck.Gen (elements, suchThat)
 
 -- | Invariant: @isAlpha . getLetter = const True@

--- a/auxx/src/Lang/Value.hs
+++ b/auxx/src/Lang/Value.hs
@@ -35,7 +35,11 @@ import           Universum
 
 import           Control.Lens (makePrisms)
 import           Data.Scientific (Scientific)
+import           Test.QuickCheck (Arbitrary (..))
+import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
 
+-- instance Arbitrary TxOut
+import           Pos.Arbitrary.Txp ()
 import           Pos.Core (AddrStakeDistribution, Address, BlockVersion, CoinPortion,
                            SoftwareVersion, StakeholderId)
 import           Pos.Core.Txp (TxOut)
@@ -46,6 +50,10 @@ data AddrDistrPart = AddrDistrPart
     { adpStakeholderId :: !StakeholderId
     , adpCoinPortion   :: !CoinPortion
     } deriving (Eq, Ord, Show, Generic)
+
+instance Arbitrary AddrDistrPart where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
 
 -- | Parameters for 'ProposeUpdate' command.
 data ProposeUpdateParams = ProposeUpdateParams
@@ -66,7 +74,11 @@ data ProposeUpdateSystem = ProposeUpdateSystem
     { pusSystemTag     :: SystemTag
     , pusInstallerPath :: Maybe FilePath
     , pusBinDiffPath   :: Maybe FilePath
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Ord, Show, Generic)
+
+instance Arbitrary ProposeUpdateSystem where
+    arbitrary = genericArbitrary
+    shrink = genericShrink
 
 data GenBlocksParams = GenBlocksParams
     { bgoBlockN :: !Word32
@@ -102,6 +114,10 @@ data Value
     | ValueAddrDistrPart AddrDistrPart
     | ValueAddrStakeDistribution AddrStakeDistribution
     | ValueFilePath FilePath
-    deriving (Eq, Ord, Show)
+    deriving (Eq, Ord, Show, Generic)
 
 makePrisms ''Value
+
+instance Arbitrary Value where
+    arbitrary = genericArbitrary
+    shrink = genericShrink

--- a/auxx/src/Plugin.hs
+++ b/auxx/src/Plugin.hs
@@ -5,7 +5,6 @@
 
 module Plugin
        ( auxxPlugin
-       , ppValue
        , rawExec
        ) where
 
@@ -17,17 +16,13 @@ import           System.Posix.Process (exitImmediately)
 #endif
 import           Control.Monad.Except (ExceptT (..), withExceptT)
 import           Data.Constraint (Dict (..))
-import           Formatting (build, char, float, int, sformat, stext, (%))
+import           Formatting (int, sformat, (%))
 import           Mockable (Delay, Mockable, delay)
 import           Serokell.Util (sec)
 import           System.IO (hFlush, stdout)
 import           System.Wlog (CanLog, HasLoggerName, logInfo)
 
 import           Pos.Communication (OutSpecs (..))
-import           Pos.Core (ApplicationName (..), SoftwareVersion (..))
-import           Pos.Core.Common (CoinPortion (..))
-import           Pos.Core.Update (BlockVersionData)
-import           Pos.Crypto (AHash (..), fullPublicKeyF, hashHexF)
 import           Pos.Diffusion.Types (Diffusion)
 import           Pos.Txp (genesisUtxo, unGenesisUtxo)
 import           Pos.Util.CompileInfo (HasCompileInfo)
@@ -37,6 +32,7 @@ import           AuxxOptions (AuxxOptions (..))
 import           Command (createCommandProcs)
 import qualified Lang
 import           Mode (MonadAuxxMode)
+import           Printer (pprValue)
 import           Repl (PrintAction, WithCommandAction (..))
 
 ----------------------------------------------------------------------------
@@ -121,51 +117,7 @@ runCmd mHasAuxxMode mDiffusion printAction line = do
         pipeline = parse >=> resolveCommandProcs >=> evaluate
     runExceptT (pipeline line) >>= \case
         Left errDoc -> printAction (Lang.renderAuxxDoc errDoc)
-        Right value -> (printAction . ppValue) value
-
-
-ppValue :: Lang.Value -> Text
-ppValue = \case
-    Lang.ValueUnit -> ""
-    Lang.ValueNumber n -> (sformat float n)
-    Lang.ValueString s -> sformat (char % stext % char) '\"' (toText s) '\"'
-    Lang.ValueBool b -> printBool b
-    Lang.ValueAddress a ->  (pretty a)
-    Lang.ValuePublicKey pk ->  (sformat fullPublicKeyF pk)
-    Lang.ValueTxOut txOut -> (pretty txOut)
-    Lang.ValueStakeholderId sId ->  (sformat hashHexF sId)
-    Lang.ValueHash h ->  (sformat hashHexF (getAHash h))
-    Lang.ValueBlockVersion v ->  (pretty v)
-    Lang.ValueSoftwareVersion v -> printSoftware v
-    Lang.ValueBlockVersionModifier bvm ->  (pretty bvm)
-    Lang.ValueBlockVersionData bvd ->  printBVD bvd
-    Lang.ValueProposeUpdateSystem pus ->  (show pus)
-    Lang.ValueAddrDistrPart adp ->  printAddrDistrPart adp
-    Lang.ValueAddrStakeDistribution asd ->  (pretty asd)
-    Lang.ValueFilePath s ->  (toText s)
-    Lang.ValueList vs -> foldMap ((mappend "  ") . ppValue) vs
-
--- need to implement printCommand with polymorphic input:
--- BlockVersionModifier or
--- BlockVersionData or
--- ProposeUpdateSystem or
--- AddrDistrPart or
--- AddrStakeDistribution or
--- TxOut -> Text
-printBool :: Bool -> Text
-printBool True  = "true"
-printBool False = "false"
-
-printSoftware :: SoftwareVersion -> Text
-printSoftware SoftwareVersion {..} =
-    sformat ("software name: "%char%stext%char%" n: "%build) '\"' (getApplicationName svAppName) '\"' svNumber
-
-printAddrDistrPart :: Lang.AddrDistrPart -> Text
-printAddrDistrPart (Lang.AddrDistrPart sId cp) =
-    sformat ("dp s: "%char%stext%char%" p: "%build) '\"' (sformat hashHexF sId) '\"' (getCoinPortion cp)
-
-printBVD :: BlockVersionData -> Text
-printBVD bvd = sformat ("bvd-read value: "%char%stext%char) '\"' (show bvd) '\"'
+        Right value -> (printAction . pprValue Nothing) value
 
 
 -- printTxOut :: TxOut -> Text

--- a/auxx/test/Test/Auxx/Printer/PrinterSpec.hs
+++ b/auxx/test/Test/Auxx/Printer/PrinterSpec.hs
@@ -7,42 +7,79 @@ import           Universum
 
 import           Control.Monad.Except (ExceptT (..), withExceptT)
 import           Data.Functor.Identity (Identity)
-import           Lang (Arg (..), Expr (..), Lit (..), Name, ProcCall (..))
-import           Lang.Syntax (AtLeastTwo (..))
-import           Lang.Value (AddrDistrPart (..))
-import           Pos.Util.CompileInfo (retrieveCompileTimeInfo, withCompileInfo)
-import           Printer (pprExpr)
+import qualified Data.Text as T
+import           Formatting (build, sformat, (%))
+import           Printer (pprExpr, valueToExpr)
 import           System.IO.Unsafe (unsafePerformIO)
 import           Test.Hspec (Expectation, Spec, SpecWith, describe, it, shouldBe)
+import qualified Test.Hspec as Hspec
 import           Test.Hspec.QuickCheck (prop)
 import           Test.QuickCheck (Arbitrary (..), Gen, Property, generate, property)
 import           Test.QuickCheck.Arbitrary.Generic (genericArbitrary, genericShrink)
-import           Text.PrettyPrint.ANSI.Leijen (Doc, text)
-
-import qualified Lang
-import qualified Test.Hspec as Hspec
+import           Text.PrettyPrint.ANSI.Leijen (Doc)
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
-spec :: Spec
-spec = describe "Auxx.Repl.ppValue" $ do
-    traverse_ itHandles expressions
-    prop "hadles any Expr" propHandleRandomExpr
+import           Command.Proc (createCommandProcs)
+import           Lang (Arg (..), Expr (..), Lit (..), Name, ProcCall (..), evaluate,
+                       resolveCommandProcs)
+import qualified Lang
+import           Lang.Syntax (AtLeastTwo (..))
+import qualified Lang.Value as Lang (Value (..))
+import           Pos.Util.CompileInfo (retrieveCompileTimeInfo, withCompileInfo)
 
-itHandles :: (Expr Name) -> SpecWith (Hspec.Arg Expectation)
-itHandles val = it ("handles " <> show val) $ exprPrinter val
+spec :: Spec
+spec = do
+    describe "Auxx.Printer.pprExpr" $ do
+        traverse_ itPrintsCorrectly expressions
+        prop "handles any Expr" propHandleRandomExpr
+    describe "Auxx.Printer.valueToExpr" $ do
+        traverse_ itConvertsCorrectly values
 
 propHandleRandomExpr :: Property
-propHandleRandomExpr = property $ ((\expr -> (parseBack_ . (pprExpr (Just 100))) expr == (Right expr)) :: Expr Name -> Bool)
+propHandleRandomExpr = property p
   where
+    parseBack_ :: Text -> Either Doc (Expr Name)
     parseBack_ = runIdentity . parseBack
 
+    p :: Expr Name -> Bool
+    p expr =
+        (parseBack_ . (pprExpr (Just 100))) expr == (Right expr)
+
+itPrintsCorrectly :: Expr Name -> SpecWith (Hspec.Arg Expectation)
+itPrintsCorrectly expr =
+    it ("handles " <> show expr) $
+        exprPrinter expr
+
+itConvertsCorrectly :: Lang.Value -> SpecWith (Hspec.Arg Expectation)
+itConvertsCorrectly val =
+    it ("handles " <> show val) $
+        valConverter val
+
 exprPrinter :: Expr Name -> Expectation
-exprPrinter expr = runIdentity $ exprPrinterId
+exprPrinter expr = runIdentity exprPrinterId
   where
     exprPrinterId :: Identity Expectation
     exprPrinterId = do
         eithParsed <- (parseBack . (pprExpr (Just 100))) expr
         return $ eithParsed `shouldBe` (Right expr)
+
+valConverter :: Lang.Value -> Expectation
+valConverter val = runIdentity valConverterId
+  where
+    valConverterId :: Identity Expectation
+    valConverterId = do
+        eithVal <- evaluate $
+            either namesNotFound identity $
+            resolveCommandProcs commandProcs $ valueToExpr val
+        return $ eithVal `shouldBe` (Right val)
+
+    namesNotFound :: NonEmpty Name -> a
+    namesNotFound names =
+        error $ sformat ("Failed to resolve names: "%build) (T.intercalate ", " $ map pretty $ toList names)
+
+    printAction _ = return ()
+    commandProcs = withCompileInfo $(retrieveCompileTimeInfo) $
+        createCommandProcs Nothing Nothing printAction Nothing :: [Lang.CommandProc Identity]
 
 parseBack :: Text -> Identity (Either Doc (Expr Name))
 parseBack line = withCompileInfo $(retrieveCompileTimeInfo) $ do
@@ -50,9 +87,12 @@ parseBack line = withCompileInfo $(retrieveCompileTimeInfo) $ do
     runExceptT (parse line) >>= \case
         Left errDoc ->
             let
-                errMsg = ((text . toString) line PP.<$> errDoc)
+                errMsg = ((PP.text . toString) line PP.<$> errDoc)
             in return $ Left errMsg
         Right expr -> return $ Right expr
+
+instance Eq Doc where
+    a == b = (show a :: Text) == (show b :: Text)
 
 instance Arbitrary (Expr Name) where
     arbitrary = genericArbitrary
@@ -74,35 +114,62 @@ instance Arbitrary (Arg (Expr Name)) where
     arbitrary = genericArbitrary
     shrink = genericShrink
 
+genUnsafe :: Gen c -> c
+genUnsafe = unsafePerformIO . generate
 expressions :: [Expr Name]
-expressions = [ ExprUnit
-              , ExprLit (LitNumber 555)
+expressions =
+    [ ExprUnit
+    , ExprLit (LitNumber 555)
               , ExprGroup (AtLeastTwo (ExprLit (LitNumber 555)) (ExprLit (LitHash $ genUnsafe arbitrary)) [])
               , ExprGroup (AtLeastTwo (ExprLit (LitNumber 555)) (ExprProcCall procCall) [])
               , ExprGroup (AtLeastTwo (ExprLit (LitNumber 555)) (ExprProcCall procCallWithFunc) [])
               , ExprGroup (AtLeastTwo (ExprLit (LitNumber 555)) (ExprProcCall procCallNestedFunc) [ExprLit (LitString "Single ident")])
-              , ExprLit (LitString "jjl")
-              , ExprLit (LitAddress $ genUnsafe arbitrary)
-              , ExprLit (LitPublicKey $ genUnsafe arbitrary)
-              , ExprLit (LitHash $ genUnsafe arbitrary)
-              , ExprLit (LitStakeholderId $ genUnsafe arbitrary)
-              , ExprLit (LitBlockVersion $ genUnsafe arbitrary)
-              , ExprLit (LitSoftwareVersion $ genUnsafe arbitrary)
-              , ExprLit (LitFilePath "/kkk")]
-
-genUnsafe :: Gen c -> c
-genUnsafe = unsafePerformIO . generate
-
-procCall, procCallWithFunc, procCallNestedFunc :: ProcCall Name (Expr Name)
-procCall = ProcCall "foo-a" [ArgKw "foo-arg" (ExprLit (LitString "argValue")), (ArgPos (ExprLit (LitString "posValue"))), ArgKw "foo-a-arg-name" (ExprLit (LitString "1 idented"))]
-procCallWithFunc = ProcCall "foo-b" [ArgKw "foo-b-arg-name" (ExprLit (LitString "argValue")), (ArgPos (ExprProcCall procCall)), ArgKw "foo-b-arg-name" (ExprLit (LitString "2 idented"))]
-procCallNestedFunc = ProcCall "foo-c" [ArgKw "foo-c-arg-name" (ExprLit (LitString "argValue")), (ArgPos (ExprProcCall procCallWithFunc))]
-
-instance Eq Doc
+    , ExprLit (LitString "jjl")
+    , ExprLit (LitAddress         $ genUnsafe arbitrary)
+    , ExprLit (LitPublicKey       $ genUnsafe arbitrary)
+    , ExprLit (LitHash            $ genUnsafe arbitrary)
+    , ExprLit (LitStakeholderId   $ genUnsafe arbitrary)
+    , ExprLit (LitBlockVersion    $ genUnsafe arbitrary)
+    , ExprLit (LitSoftwareVersion $ genUnsafe arbitrary)
+    , ExprLit (LitFilePath "/kkk")
+    ]
+  where
+    procCall, procCallWithFunc, procCallNestedFunc :: ProcCall Name (Expr Name)
+    procCall = ProcCall "foo-a"
+        [ ArgKw "foo-arg" (ExprLit (LitString "argValue"))
+        , ArgPos (ExprLit (LitString "posValue"))
+        , ArgKw "foo-a-arg-name" (ExprLit (LitString "1 idented"))
+        ]
+    procCallWithFunc = ProcCall "foo-b"
+        [ ArgKw "foo-b-arg-name" (ExprLit (LitString "argValue"))
+        , ArgPos (ExprProcCall procCall)
+        , ArgKw "foo-b-arg-name" (ExprLit (LitString "2 idented"))
+        ]
+    procCallNestedFunc = ProcCall "foo-c"
+        [ ArgKw "foo-c-arg-name" (ExprLit (LitString "argValue"))
+        , ArgPos (ExprProcCall procCallWithFunc)
+        ]
 
 data RunErr = ParseError | EvalError deriving (Eq, Show)
 instance Exception RunErr
 
-instance Arbitrary AddrDistrPart where
-    arbitrary = genericArbitrary
-    shrink = genericShrink
+values :: [Lang.Value]
+values =
+    [ Lang.ValueNumber                $ genUnsafe arbitrary
+    , Lang.ValueString                $ genUnsafe arbitrary
+    , Lang.ValueAddress               $ genUnsafe arbitrary
+    , Lang.ValueBool                  $ genUnsafe arbitrary
+    , Lang.ValueFilePath              "/dev"
+    , Lang.ValuePublicKey             $ genUnsafe arbitrary
+    , Lang.ValueStakeholderId         $ genUnsafe arbitrary
+    , Lang.ValueHash                  $ genUnsafe arbitrary
+    , Lang.ValueBlockVersion          $ genUnsafe arbitrary
+    , Lang.ValueSoftwareVersion       $ genUnsafe arbitrary
+    , Lang.ValueBlockVersionModifier  $ genUnsafe arbitrary
+    , Lang.ValueBlockVersionData      $ genUnsafe arbitrary
+    , Lang.ValueProposeUpdateSystem   $ genUnsafe arbitrary
+    , Lang.ValueAddrDistrPart         $ genUnsafe arbitrary
+    , Lang.ValueAddrStakeDistribution $ genUnsafe arbitrary
+    , Lang.ValueTxOut                 $ genUnsafe arbitrary
+    , Lang.ValueList                  $ genUnsafe arbitrary
+    ]


### PR DESCRIPTION
TODO:

- [ ] [postponed after discussion with @int-index] Refactor tests to not use `unsafePerformIO $ generate arbitrary`
- [ ] [postponed after discussion with @int-index] Write an `Arbitrary` instance for `FilePath`

Make all tests pass:
- [x] `ValueNumber`
- [x] `ValueString`
- [x] `ValueAddress`
- [x] `ValueBool`
- [x] `ValueFilePath`
- [x] `ValuePublicKey`
- [x] `ValueStakeholderId`
- [x] `ValueHash`
- [x] `ValueBlockVersion`
- [x] `ValueSoftwareVersion`
- [ ] `ValueBlockVersionModifier`
  - [ ] Support `bvmUpdateImplicit`
  - [ ] Support `bvmSoftforkRule`
  - [ ] Support `bvmTxFeePolicy`
- [ ] `ValueBlockVersionData`
  - [ ] Replace `read` which doesn't work with times (like `536007ms`) with something that does
- [x] `ValueProposeUpdateSystem`
  - [x] Fix `SystemTag` rendering
- [ ] `ValueAddrDistrPart`
  - [ ] Run `dp` in `Identity`
- [ ] `ValueAddrStakeDistribution`
  - [ ] Run `distr` (and `dp`) in `Identity`
- [x] `ValueTxOut`
- [x] `ValueList`
