### PR TITLE
[AD-178] Always throw exceptions if UserSecret is malformed

### DIFF
--- a/lib/src/Pos/Util/UserSecret.hs
+++ b/lib/src/Pos/Util/UserSecret.hs
@@ -294,7 +294,7 @@ initializeUserSecret secretPath = do
 #endif
   where
     createEmptyFile :: (MonadIO m) => FilePath -> m ()
-    createEmptyFile = liftIO . flip writeFile mempty
+    createEmptyFile = liftIO . flip BS.writeFile (serialize' @UserSecret def)
 
 -- | Reads user secret from file, assuming that file exists,
 -- and has mode 600, throws exception in other case


### PR DESCRIPTION
Some functions throw exceptions, some functions don't. Not throwing
exceptions is dangerous because it may cause data loss. It's better not
to silently override malformed secret.