### PR TITLE
[AD-428] Fix logException

### DIFF
--- a/util/Pos/Util/Util.hs
+++ b/util/Pos/Util/Util.hs
@@ -319,7 +319,7 @@ multilineBounds maxSize = F.later formatList
 
 -- | Catch and log an exception, then rethrow it
 logException :: LoggerName -> IO a -> IO a
-logException name = E.handleAsync (\e -> handler e >> E.throw e)
+logException name action = E.withException action handler
   where
     handler :: E.SomeException -> IO ()
     handler exc = do


### PR DESCRIPTION
## Description

Control.Exception.Safe.handleAsync followed by throw from the same
package will re-throw async exception as sync one wrapping it in
SyncExceptionWrapper. This is not an expected behavior from a log
wrapper. withException will automatically re-throw the exception in a
more sane manner.

## Linked issue

https://issues.serokell.io/issue/AD-428

serokell/ariadne#338
