### PR TITLE
[AD-512] Revert UserSecret-related changes

### DIFF
--- a/tools/src/keygen/Main.hs
+++ b/tools/src/keygen/Main.hs
@@ -25,7 +25,7 @@ import           Pos.Crypto (EncryptedSecretKey (..), SecretKey (..), VssKeyPair
                              hashHexF, noPassEncrypt, redeemPkB64F, toPublic, toVssPublicKey)
 import           Pos.Launcher (HasConfigurations, withConfigurations)
 import           Pos.Util.UserSecret (readUserSecret, takeUserSecret, usKeys, usPrimKey, usVss,
-                                      writeUserSecretRelease)
+                                      usWallet, writeUserSecretRelease, wusRootKey)
 
 import           Dump (dumpFakeAvvmSeed, dumpGeneratedGenesisData, dumpRichSecrets)
 import           KeygenOptions (DumpAvvmSeedsOptions (..), GenKeysOptions (..), KeygenCommand (..),
@@ -69,6 +69,9 @@ readKey path = do
     logInfo $ maybe "No Primary key"
                     (("Primary: " <>) . showKeyWithAddressHash) $
                     view usPrimKey us
+    logInfo $ maybe "No wallet set"
+                    (("Wallet set: " <>) . showKeyWithAddressHash . decryptESK . view wusRootKey) $
+                    view usWallet us
     logInfo $ "Keys: " <> (T.concat $ L.intersperse "\n" $
                            map (showKeyWithAddressHash . decryptESK) $
                            view usKeys us)

--- a/util/Pos/Util/Lens.hs
+++ b/util/Pos/Util/Lens.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE Rank2Types #-}
-
 -- | Utilities related to 'lens' package.
 
 module Pos.Util.Lens
@@ -8,7 +6,6 @@ module Pos.Util.Lens
          _neHead
        , _neTail
        , _neLast
-       , listLens
 
        -- * Custom LensRules
        , postfixLFields
@@ -16,12 +13,10 @@ module Pos.Util.Lens
 
        ) where
 
-import           Universum hiding (init, last)
 import           Data.List (init, last)
+import           Universum hiding (init, last)
 
-import           Control.Applicative (ZipList (..))
-import           Control.Lens (Iso', LensRules, coerced, from, lens, lensField, lensRules,
-                               mappingNamer)
+import           Control.Lens (LensRules, lensField, lensRules, mappingNamer)
 
 -- | Lens for the head of 'NonEmpty'.
 --
@@ -39,24 +34,6 @@ _neTail f (x :| xs) = (x :|) <$> f xs
 _neLast :: Lens' (NonEmpty a) a
 _neLast f (x :| []) = (:| []) <$> f x
 _neLast f (x :| xs) = (\y -> x :| init xs ++ [y]) <$> f (last xs)
-
--- Something weird, but maybe it's useful, I dunno.
-applicativeLens :: forall f s a b. Applicative f => Lens' s (f a) -> Lens' a b -> Lens' s (f b)
-applicativeLens lfa lb = lens (map (view lb) . view lfa) setter
-  where
-    setter :: s -> f b -> s
-    setter s fb = s & lfa %~ (\fa -> set lb <$> fb <*> fa)
-
--- | If you have a lens from something to list of 'a' and from 'a' to
--- 'b', this function will create a function from that /something/ to
--- list of 'b'.
-listLens :: forall s a b. Lens' s [a] -> Lens' a b -> Lens' s [b]
-listLens lensToList lensToB = l . from _ZipList
-  where
-    _ZipList :: forall x. Iso' [x] (ZipList x)
-    _ZipList = coerced
-    l :: Lens' s (ZipList b)
-    l = applicativeLens (lensToList . _ZipList) lensToB
 
 ----------------------------------------------------------------------------
 -- Custom LensRules

--- a/wallet/src/Pos/Wallet/Web/Mode.hs
+++ b/wallet/src/Pos/Wallet/Web/Mode.hs
@@ -334,7 +334,7 @@ instance MonadKeysRead WalletWebMode where
     getSecret = getSecretDefault
 
 instance MonadKeys WalletWebMode where
-    modifySecretNew = modifySecretDefault
+    modifySecret = modifySecretDefault
 
 getNewAddressWebWallet
     :: MonadWalletLogic ctx m

--- a/wallet/test/Test/Pos/Wallet/Web/Mode.hs
+++ b/wallet/test/Test/Pos/Wallet/Web/Mode.hs
@@ -377,7 +377,7 @@ instance MonadKeysRead WalletTestMode where
     getSecret = getSecretDefault
 
 instance MonadKeys WalletTestMode where
-    modifySecretNew = modifySecretPureDefault
+    modifySecret = modifySecretPureDefault
 
 instance (HasConfigurations) => MonadTxHistory WalletTestMode where
     getBlockHistory = getBlockHistoryDefault


### PR DESCRIPTION
## Description

Problem: we've made some changes related to UserSecret because we wanted to
use this type in Ariadne, but not exactly this type as is. However, we don't
use this type anymore. And we want to keep diff with IOHK version as small as
possible to make merging IOHK version easier in future.
Solution: revert all changes, so that files in question correspond to upstream
cardano-sl-1.3.2.

<!--- A brief description of this PR and the problem is trying to solve -->

## Linked issue

https://issues.serokell.io/issue/AD-512

